### PR TITLE
fix: ensure vbloods never contains null elements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -21,6 +21,7 @@ csharp_new_line_before_finally = false
 csharp_space_around_declaration_statements = ignore
 csharp_space_after_cast = true
 csharp_preferred_modifier_order = public, private, protected, internal, file, new, static, abstract, virtual, sealed, readonly, override, extern, unsafe, volatile, async, required
+resharper_space_after_cast = true
 resharper_csharp_place_attribute_on_same_line = never
 resharper_place_field_attribute_on_same_line = never
 resharper_place_method_attribute_on_same_line = never

--- a/character/CharacterInfoCommand.cs
+++ b/character/CharacterInfoCommand.cs
@@ -24,13 +24,17 @@ public static class CharacterInfoCommand {
                 var killedVBloods = new List<VBlood>();
                 var hasProgression = ProgressionUtility.TryGetProgressionEntity(entityManager, player.VUser.UserEntity, out var progressionEntity);
                 if (hasProgression) {
-                    ListUtils.Convert(entityManager.GetBuffer<UnlockedVBlood>(progressionEntity))
-                        .ForEach(vBlood => killedVBloods.Add((VBlood)vBlood.VBlood.GuidHash));
+                    foreach (var unlockedVBlood in entityManager.GetBuffer<UnlockedVBlood>(progressionEntity)) {
+                        VBlood? vBlood = (VBlood?) unlockedVBlood.VBlood.GuidHash;
+                        if (vBlood != null) {
+                            killedVBloods.Add((VBlood) vBlood);
+                        }
+                    }
                 }
 
                 return new CharacterResponse(
-                    Name: ((VCharacter)player.VCharacter!).Character.Name.ToString(),
-                    GearLevel: ((VCharacter)player.VCharacter!).getGearLevel(),
+                    Name: ((VCharacter) player.VCharacter!).Character.Name.ToString(),
+                    GearLevel: ((VCharacter) player.VCharacter!).getGearLevel(),
                     Clan: clan,
                     KilledVBloods: killedVBloods
                 );


### PR DESCRIPTION
Some players have more than 57 vbloods in their `UnlockedVBlood` buffer. This ensures we only return "known" vbloods in `/v-rising-discord-bot/characters`