### PR TITLE
feat: basic auth for all api endpoints

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -1,5 +1,7 @@
-﻿using System.Reflection;
+﻿using System.Collections.Generic;
+using System.Reflection;
 using BepInEx;
+using BepInEx.Configuration;
 using BepInEx.Logging;
 using BepInEx.Unity.IL2CPP;
 using Bloodstone.API;
@@ -16,8 +18,25 @@ namespace v_rising_discord_bot_companion;
 public class Plugin : BasePlugin {
 
     public static ManualLogSource Logger = null!;
+    public static Plugin Instance { get; private set; }
     private Harmony? _harmony;
     private Component? _queryDispatcher;
+
+    private PluginConfig? _pluginConfig;
+    private ConfigEntry<string> _basicAuthUsers;
+
+    public Plugin() {
+
+        Instance = this;
+        Logger = Log;
+
+        _basicAuthUsers = Config.Bind(
+            "Authentication",
+            "BasicAuthUsers",
+            "",
+            "A list of comma separated username:password entries that are allowed to query the HTTP API."
+        );
+    }
 
     public override void Load() {
 
@@ -26,7 +45,6 @@ public class Plugin : BasePlugin {
             return;
         }
 
-        Logger = Log;
 
         // Plugin startup logic
         Log.LogInfo($"Plugin {MyPluginInfo.PLUGIN_GUID} version {MyPluginInfo.PLUGIN_VERSION} is loaded!");
@@ -45,6 +63,32 @@ public class Plugin : BasePlugin {
         if (_queryDispatcher != null) {
             Object.Destroy(_queryDispatcher);
         }
+        _pluginConfig = null;
         return true;
+    }
+
+    public PluginConfig GetPluginConfig() {
+        _pluginConfig ??= ParsePluginConfig();
+        return (PluginConfig) _pluginConfig;
+    }
+
+    private PluginConfig ParsePluginConfig() {
+
+        var basicAuthUsers = new List<BasicAuthUser>();
+        foreach (var basicAuthUser in _basicAuthUsers.Value.Split(",")) {
+            var parts = basicAuthUser.Split(":");
+            if (parts.Length == 2) {
+                basicAuthUsers.Add(
+                    new BasicAuthUser(
+                        Username: parts[0].Trim(),
+                        Password: parts[1].Trim()
+                    )
+                );
+            }
+        }
+
+        return new PluginConfig(
+            BasicAuthUsers: basicAuthUsers
+        );
     }
 }

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -17,7 +17,7 @@ namespace v_rising_discord_bot_companion;
 [Reloadable]
 public class Plugin : BasePlugin {
 
-    public static ManualLogSource Logger = null!;
+    public static ManualLogSource Logger { get; private set; } = null!;
     public static Plugin Instance { get; private set; }
     private Harmony? _harmony;
     private Component? _queryDispatcher;

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -18,7 +18,7 @@ namespace v_rising_discord_bot_companion;
 public class Plugin : BasePlugin {
 
     public static ManualLogSource Logger { get; private set; } = null!;
-    public static Plugin Instance { get; private set; }
+    public static Plugin Instance { get; private set; } = null!;
     private Harmony? _harmony;
     private Component? _queryDispatcher;
 

--- a/PluginConfig.cs
+++ b/PluginConfig.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+
+namespace v_rising_discord_bot_companion;
+
+public readonly record struct PluginConfig(
+    List<BasicAuthUser> BasicAuthUsers
+);
+
+public readonly record struct BasicAuthUser(
+    string Username,
+    string Password
+);

--- a/command/HttpReceiveServicePatches.cs
+++ b/command/HttpReceiveServicePatches.cs
@@ -26,7 +26,7 @@ public class HttpReceiveServicePatches {
         }
 
         __result = IsAuthorized((BasicAuthUser) currentBasicAuthUser);
-        return false;
+        return __result;
     }
 
     private static BasicAuthUser? ParseBasicAuthUser(HttpListenerContext context) {

--- a/command/HttpReceiveServicePatches.cs
+++ b/command/HttpReceiveServicePatches.cs
@@ -1,0 +1,64 @@
+﻿using System.Linq;
+using HarmonyLib;
+using Il2CppSystem.Net;
+using Il2CppSystem.Security.Principal;
+using ProjectM.Network;
+
+namespace v_rising_discord_bot_companion.command;
+
+[HarmonyPatch(typeof(HttpServiceReceiveThread))]
+public class HttpReceiveServicePatches {
+
+    [HarmonyPrefix]
+    [HarmonyPatch("IsAllowed")]
+    public static bool IsAllowed(HttpListenerContext context, ref bool __result) {
+
+        var pluginConfig = Plugin.Instance.GetPluginConfig();
+
+        if (pluginConfig.BasicAuthUsers.Count <= 0) {
+            return true;
+        }
+
+        var currentBasicAuthUser = ParseBasicAuthUser(context);
+        if (!currentBasicAuthUser.HasValue) {
+            __result = false;
+            return false;
+        }
+
+        __result = IsAuthorized((BasicAuthUser) currentBasicAuthUser);
+        return false;
+    }
+
+    private static BasicAuthUser? ParseBasicAuthUser(HttpListenerContext context) {
+
+        context.ParseAuthentication(AuthenticationSchemes.Basic);
+
+        if (context.user == null) {
+            return null;
+        }
+
+        var principal = context.user.TryCast<GenericPrincipal>();
+        var identity = principal?.m_identity.TryCast<HttpListenerBasicIdentity>();
+
+        if (identity == null) {
+            return null;
+        }
+
+        var username = identity.Name;
+        var password = identity.password;
+
+        if (username == null || password == null) {
+            return null;
+        }
+
+        return new BasicAuthUser(
+            Username: username,
+            Password: password
+        );
+    }
+
+    private static bool IsAuthorized(BasicAuthUser currentBasicAuthUser) {
+        return Plugin.Instance.GetPluginConfig().BasicAuthUsers
+            .Count(it => it.Username.Equals(currentBasicAuthUser.Username) && it.Password.Equals(currentBasicAuthUser.Password)) == 1;
+    }
+}

--- a/command/ServerWebAPISystemPatches.cs
+++ b/command/ServerWebAPISystemPatches.cs
@@ -30,6 +30,7 @@ public class ServerWebAPISystemPatches {
     public static void OnCreate(ServerWebAPISystem __instance) {
 
         if (!SettingsManager.ServerHostSettings.API.Enabled) {
+            Plugin.Logger.LogInfo($"HTTP API is not enabled.");
             return;
         }
 
@@ -50,6 +51,8 @@ public class ServerWebAPISystemPatches {
             "GET",
             BuildAdapter(_ => VampireDownedServerEventSystemPatches.getPvpKills())
         ));
+
+        Plugin.Logger.LogInfo($"Added v-rising-discord-bot endpoints.");
     }
 
     private static HttpServiceReceiveThread.RequestHandler BuildAdapter(Func<HttpListenerContext, object> commandHandler) {

--- a/http-requests.http
+++ b/http-requests.http
@@ -6,3 +6,31 @@ GET http://localhost:25570/v-rising-discord-bot/player-activities
 
 ### Get pvp kills
 GET http://localhost:25570/v-rising-discord-bot/pvp-kills
+
+### Metrics
+GET http://localhost:25570/metrics
+
+### Console
+GET http://localhost:25570/console/v1?input=sendserverannouncement some message
+
+### Messages
+POST http://localhost:25570/api/message/v1
+Content-Type: application/json
+
+{
+    "message": "the actual message"
+}
+
+### Shutdown
+POST http://localhost:25570/api/shutdown/v1
+Content-Type: application/json
+
+{
+    "shutdown": true
+}
+
+### Save
+POST http://localhost:25570/api/save/v1
+Content-Type: application/json
+
+{}


### PR DESCRIPTION
# Description

Allows users to secure all endpoints on the API port using [Basic Auth](https://en.wikipedia.org/wiki/Basic_access_authentication). See also: https://github.com/DarkAtra/v-rising-discord-bot/issues/105.

> [!Warning]
> Enabling basic auth will secure all endpoints on the API port, including the default ones from Stunlock and endpoints that other plugins might've added.

# How to use it

After installing the bot companion and starting the v rising server once, you should find a file `v-rising-discord-bot-companion.cfg` in `BepInEx\config` with the following content:

```
## Settings file was created by plugin v-rising-discord-bot-companion v0.4.1
## Plugin GUID: v-rising-discord-bot-companion

[Authentication]

## A list of comma separated username:password entries that are allowed to query the HTTP API.
# Setting type: String
# Default value: 
BasicAuthUsers = 
```

To enable basic auth for all api endpoints (including the default endpoints, such as `/metrics`) just put the desired username and password after `BasicAuthUsers = `. For example, the following config would configure a user `myuser` with `1234` as its password:

```
## Settings file was created by plugin v-rising-discord-bot-companion v0.4.1
## Plugin GUID: v-rising-discord-bot-companion

[Authentication]

## A list of comma separated username:password entries that are allowed to query the HTTP API.
# Setting type: String
# Default value: 
BasicAuthUsers = myuser:1234
```

You can also add more than one user like this:

```
## Settings file was created by plugin v-rising-discord-bot-companion v0.4.1
## Plugin GUID: v-rising-discord-bot-companion

[Authentication]

## A list of comma separated username:password entries that are allowed to query the HTTP API.
# Setting type: String
# Default value: 
BasicAuthUsers = myuser:1234,seconduser:somepassword
```