### PR TITLE
feat: post global chat messages to discord

### DIFF
--- a/PluginConfig.cs
+++ b/PluginConfig.cs
@@ -3,7 +3,10 @@
 namespace v_rising_discord_bot_companion;
 
 public readonly record struct PluginConfig(
-    List<BasicAuthUser> BasicAuthUsers
+    List<BasicAuthUser> BasicAuthUsers,
+    string? DiscordWebhookUrl,
+    string DiscordWebhookUsername,
+    string DiscordWebhookAvatarUrl
 );
 
 public readonly record struct BasicAuthUser(

--- a/chat/DiscordChatSystem.cs
+++ b/chat/DiscordChatSystem.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Bloodstone.Hooks;
+using ProjectM.Network;
+
+namespace v_rising_discord_bot_companion.chat;
+
+public class DiscordChatSystem {
+
+    private static readonly int MAX_MESSAGE_LENGTH = 2000;
+
+    private static readonly HttpClient _httpClient = new();
+    private static readonly JsonSerializerOptions _serializeOptions = new() {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
+    };
+
+    public static void HandleChatEvent(VChatEvent vChatEvent) {
+
+        var pluginConfig = Plugin.Instance.GetPluginConfig();
+        var discordWebhookUrl = pluginConfig.DiscordWebhookUrl;
+        if (discordWebhookUrl == null || vChatEvent.Type != ChatMessageType.Global) {
+            return;
+        }
+
+        try {
+
+            var webhookRequestPayload = new DiscordWebhookRequestPayload(
+                Username: pluginConfig.DiscordWebhookUsername,
+                AvatarUrl: pluginConfig.DiscordWebhookAvatarUrl,
+                Content: $"{vChatEvent.User.CharacterName}: {vChatEvent.Message.Substring(0, Math.Min(vChatEvent.Message.Length, MAX_MESSAGE_LENGTH - vChatEvent.User.CharacterName.Length))}"
+            );
+
+            var webhookRequest = new HttpRequestMessage(HttpMethod.Post, discordWebhookUrl) {
+                Content = new StringContent(
+                    JsonSerializer.Serialize(webhookRequestPayload, _serializeOptions),
+                    Encoding.UTF8,
+                    "application/json"
+                )
+            };
+
+            var response = _httpClient.Send(webhookRequest);
+            if (response.StatusCode != HttpStatusCode.NoContent) {
+                Plugin.Logger.LogError($"Discord webhook responded with unexpected status code '{response.StatusCode}' - please check your configuration");
+            }
+        } catch (Exception e) {
+            Plugin.Logger.LogError($"Exception calling discord webhook: {e.Message}");
+        }
+    }
+}

--- a/chat/DiscordWebhookRequestPayload.cs
+++ b/chat/DiscordWebhookRequestPayload.cs
@@ -1,0 +1,7 @@
+﻿namespace v_rising_discord_bot_companion.chat;
+
+public readonly record struct DiscordWebhookRequestPayload(
+    string Username,
+    string Content,
+    string AvatarUrl
+);

--- a/http-requests.http
+++ b/http-requests.http
@@ -34,3 +34,13 @@ POST http://localhost:25570/api/save/v1
 Content-Type: application/json
 
 {}
+
+### Discord Webhook
+POST https://discord.com/api/webhooks/xxx/xxx
+Content-Type: application/json
+
+{
+    "username": "Jarvis",
+    "avatar_url": "https://raw.githubusercontent.com/DarkAtra/v-rising-discord-bot/main/docs/assets/icon.png",
+    "content": "Atra: Test"
+}

--- a/v-rising-discord-bot-companion.csproj
+++ b/v-rising-discord-bot-companion.csproj
@@ -4,7 +4,7 @@
         <Description>A companion mod for DarkAtra/v-rising-discord-bot.</Description>
         <Version>0.4.1</Version>
 
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <Nullable>enable</Nullable>


### PR DESCRIPTION
Allows server owners to use a discord webhook to post ingame chat messages (global only) to discord.